### PR TITLE
fix: update rule manager after cloning rules in mobile and general settings sections

### DIFF
--- a/src/settings/mobile/sections/MobileRulesSection.ts
+++ b/src/settings/mobile/sections/MobileRulesSection.ts
@@ -155,6 +155,7 @@ export class MobileRulesSection {
           clonedRule.name = `${baseName} (copy)`;
           rulesV2.splice(index + 1, 0, clonedRule);
           await this.plugin.save_settings();
+          this.plugin.noteMover.updateRuleManager();
           if (this.refreshDisplay) {
             this.refreshDisplay();
           }

--- a/src/settings/sections/RulesSettingsSection.ts
+++ b/src/settings/sections/RulesSettingsSection.ts
@@ -350,6 +350,7 @@ export class RulesSettingsSection {
               clonedRule
             );
             await this.plugin.save_settings();
+            this.plugin.noteMover.updateRuleManager();
             this.refreshDisplay();
           })
       );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures cloned rules are applied immediately by refreshing the active rule manager post-clone.
> 
> - Add `this.plugin.noteMover.updateRuleManager()` after rule cloning in `MobileRulesSection.ts` and `RulesSettingsSection.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46aaaf8d6cc63c14ba3f0cc7f1bc66c1b8640e82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->