### PR TITLE
added property sanitization to template rules

### DIFF
--- a/src/core/RuleManagerV2.ts
+++ b/src/core/RuleManagerV2.ts
@@ -3,7 +3,7 @@ import { NoticeManager } from '../utils/NoticeManager';
 import { RuleV2 } from '../types/RuleV2';
 import { PreviewEntry, MovePreview } from '../types/MovePreview';
 import { createError, handleError } from '../utils/Error';
-import { combinePath } from '../utils/PathUtils';
+import { combinePath, formatPath } from '../utils/PathUtils';
 import { MetadataExtractor } from './MetadataExtractor';
 import { RuleMatcherV2 } from './RuleMatcherV2';
 import { RuleMatcher } from './RuleMatcher';
@@ -156,10 +156,13 @@ export class RuleManagerV2 {
       );
 
       if (matchingRule) {
-        const targetFolder = this.resolveDestinationTemplate(
+        let targetFolder = this.resolveDestinationTemplate(
           matchingRule.destination,
           metadata
         );
+
+        // Sanitize the resolved destination to unwrap wikilinks and remove invalid chars
+        targetFolder = formatPath(targetFolder);
 
         // If the destination template resolves to an empty value, treat it as
         // "no valid move target" so the file is left unmoved.

--- a/src/utils/PathUtils.ts
+++ b/src/utils/PathUtils.ts
@@ -1,5 +1,40 @@
 import { App } from 'obsidian';
 
+const INVALID_PATH_CHARS = /[<>:"\\|?*]/g;
+const WINDOWS_RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
+function unwrapWikilinks(value: string): string {
+  return value.replace(/\[\[([^\]]+)\]\]/g, (_match, inner: string) => {
+    // Prefer alias text for [[target|alias]] and drop heading/block suffixes.
+    const aliasOrTarget = inner.split('|').pop()?.trim() || '';
+    return aliasOrTarget.replace(/[#^].*$/, '').trim();
+  });
+}
+
+function sanitizePathSegment(segment: string): string {
+  segment = unwrapWikilinks(segment);
+
+  // Remove characters that are invalid on major desktop filesystems.
+  let sanitized = segment
+    .replace(INVALID_PATH_CHARS, '')
+    .split('')
+    .filter(char => char.charCodeAt(0) >= 32)
+    .join('');
+
+  // Windows does not allow trailing spaces or periods in a segment.
+  sanitized = sanitized.replace(/[. ]+$/g, '');
+
+  if (sanitized === '.' || sanitized === '..') {
+    return '';
+  }
+
+  if (WINDOWS_RESERVED_NAMES.test(sanitized)) {
+    sanitized = `${sanitized}_`;
+  }
+
+  return sanitized;
+}
+
 /**
  * Formats a path correctly by removing double slashes
  * and ensuring the path is relative to vault root (no leading slash)
@@ -12,6 +47,13 @@ export function formatPath(path: string): string {
 
   // Remove double slashes first
   path = path.replace(/\/+/g, '/');
+
+  // Sanitize each path segment while preserving folder separators.
+  path = path
+    .split('/')
+    .map(segment => sanitizePathSegment(segment))
+    .filter(segment => segment.length > 0)
+    .join('/');
 
   // Remove trailing slash
   if (path.endsWith('/')) {


### PR DESCRIPTION
I wanted to add some sanitization to the `{{property.name}}` template rule fields. 

While I realize that CONTRIBUTING.md explicitly states to PR off of dev, I noticed that dev does not contain recent commits, and main does. 

