### PR TITLE
Feat/move-attachments-with-note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Features
 
+- **Move attachments with note** ([#77](https://github.com/bueckerlars/obsidian-note-mover-shortcut/issues/77)): Optional co-move of referenced attachment files in the note folder subtree when a markdown note is moved (preserves relative paths such as `_assets/`). Configurable in Triggers; off by default on upgrade, on for new installs. Undo restores co-moved attachments.
 - **Preview bulk cancel**: While executing moves from the preview modal, you can **Stop** the remaining renames; completed moves stay in history.
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **Blacklist filters**: exclude notes by tag, path, filename pattern, property, date prefix, or body substring (`content:`).
 - **Commands**: move the active note, move all Markdown notes, previews, history, and “add current file to blacklist.”
 - **Automation**: optional move-on-edit (debounced) and periodic full-vault passes.
+- **Attachment co-move**: optionally move images and other attachments referenced in a note when it moves, preserving relative paths (e.g. `_assets/` next to the note). See settings under Triggers.
 - **Performance options**: rule evaluation cache and vault index cache; optional performance tracing for debugging.
 
 ## Requirements

--- a/docs/commands-triggers-internals.md
+++ b/docs/commands-triggers-internals.md
@@ -47,7 +47,7 @@ For canvas and base files, rule criteria based on tags, properties, links, or he
 3. If result is `null`, **no move**.
 4. If target path equals current path, **no move**.
 5. `ensureFolderExists` for the target folder, then `performNoteMove` (`src/application/perform-note-move.ts`).
-6. **Optional attachment co-move** (when `settings.attachments.moveWithNote` is enabled): before the note rename, referenced attachments under the note folder are collected from the metadata cache; after the note rename, each attachment is moved to the same relative path beside the new note location (e.g. `Folder A/_assets/x.png` → `Folder B/_assets/x.png`). Shared attachments can be skipped via `skipSharedAttachments`.
+6. **Optional attachment co-move** (when `settings.attachments.moveWithNote` is enabled): before the note rename, referenced attachments under the note folder are collected from the metadata cache; after the note rename, each attachment is moved to the same relative path beside the new note location (e.g. `Folder A/_assets/x.png` → `Folder B/_assets/x.png`). Shared attachments can be skipped via `skipSharedAttachments`. When `deleteEmptyAssetFolders` is enabled, empty source attachment folders (e.g. `Folder A/_assets`) are removed after the co-move.
 7. History entry recorded (including `attachmentMoves` when applicable); notices/undo restore the note and co-moved attachments.
 
 ## Rule evaluation cache

--- a/docs/commands-triggers-internals.md
+++ b/docs/commands-triggers-internals.md
@@ -46,8 +46,9 @@ For canvas and base files, rule criteria based on tags, properties, links, or he
 2. `RuleManagerV2.moveFileBasedOnTags` → metadata + blacklist + first matching rule + destination resolution.
 3. If result is `null`, **no move**.
 4. If target path equals current path, **no move**.
-5. `ensureFolderExists` for the target folder, then `app.fileManager.renameFile`.
-6. History entry recorded; notices/undo wired for the focused-note command.
+5. `ensureFolderExists` for the target folder, then `performNoteMove` (`src/application/perform-note-move.ts`).
+6. **Optional attachment co-move** (when `settings.attachments.moveWithNote` is enabled): before the note rename, referenced attachments under the note folder are collected from the metadata cache; after the note rename, each attachment is moved to the same relative path beside the new note location (e.g. `Folder A/_assets/x.png` → `Folder B/_assets/x.png`). Shared attachments can be skipped via `skipSharedAttachments`.
+7. History entry recorded (including `attachmentMoves` when applicable); notices/undo restore the note and co-moved attachments.
 
 ## Rule evaluation cache
 

--- a/src/application/co-move-attachments-on-note-move.ts
+++ b/src/application/co-move-attachments-on-note-move.ts
@@ -1,0 +1,67 @@
+import type { App } from 'obsidian';
+import { TFile } from 'obsidian';
+import type { AttachmentMovePlan } from '../domain/attachments/note-attachments';
+import { ensureFolderExists, getParentPath } from '../utils/PathUtils';
+
+export interface AttachmentMoveRecord {
+  sourcePath: string;
+  destinationPath: string;
+}
+
+export interface CoMoveAttachmentsOptions {
+  plans: AttachmentMovePlan[];
+}
+
+/**
+ * Renames attachment files after their parent note has moved.
+ * Skips destinations that already exist.
+ */
+export async function coMoveAttachmentsAfterNoteRename(
+  app: App,
+  options: CoMoveAttachmentsOptions
+): Promise<AttachmentMoveRecord[]> {
+  const moved: AttachmentMoveRecord[] = [];
+
+  for (const plan of options.plans) {
+    const destExists = await app.vault.adapter.exists(plan.destinationPath);
+    if (destExists) {
+      console.warn(
+        `[Advanced Note Mover] Skipping attachment move; destination exists: ${plan.destinationPath}`
+      );
+      continue;
+    }
+
+    const destFolder = getParentPath(plan.destinationPath);
+    if (destFolder && !(await ensureFolderExists(app, destFolder))) {
+      console.warn(
+        `[Advanced Note Mover] Failed to create folder for attachment: ${destFolder}`
+      );
+      continue;
+    }
+
+    const file =
+      plan.file ??
+      (app.vault.getAbstractFileByPath(plan.sourcePath) as TFile | null);
+    if (!(file instanceof TFile)) {
+      console.warn(
+        `[Advanced Note Mover] Attachment not found: ${plan.sourcePath}`
+      );
+      continue;
+    }
+
+    try {
+      await app.fileManager.renameFile(file, plan.destinationPath);
+      moved.push({
+        sourcePath: plan.sourcePath,
+        destinationPath: plan.destinationPath,
+      });
+    } catch (error) {
+      console.warn(
+        `[Advanced Note Mover] Failed to move attachment ${plan.sourcePath}:`,
+        error
+      );
+    }
+  }
+
+  return moved;
+}

--- a/src/application/perform-note-move.ts
+++ b/src/application/perform-note-move.ts
@@ -1,0 +1,66 @@
+import type { App } from 'obsidian';
+import { TFile } from 'obsidian';
+import { buildAttachmentMovePlans } from '../domain/attachments/note-attachments';
+import {
+  coMoveAttachmentsAfterNoteRename,
+  type AttachmentMoveRecord,
+} from './co-move-attachments-on-note-move';
+import type { AttachmentMoveSettings } from '../types/PluginData';
+import type { HistoryManager } from '../core/HistoryManager';
+
+export interface PerformNoteMoveOptions {
+  app: App;
+  historyManager: HistoryManager;
+  file: TFile;
+  originalPath: string;
+  newPath: string;
+  attachmentSettings: AttachmentMoveSettings;
+}
+
+/**
+ * Renames a note and optionally co-moves referenced attachments, recording history.
+ */
+export async function performNoteMove(
+  options: PerformNoteMoveOptions
+): Promise<AttachmentMoveRecord[]> {
+  const {
+    app,
+    historyManager,
+    file,
+    originalPath,
+    newPath,
+    attachmentSettings,
+  } = options;
+
+  const shouldCoMove =
+    attachmentSettings.moveWithNote && file.extension === 'md';
+
+  const attachmentPlans = shouldCoMove
+    ? buildAttachmentMovePlans(app, file, originalPath, newPath, {
+        skipSharedAttachments: attachmentSettings.skipSharedAttachments,
+      })
+    : [];
+
+  historyManager.markPluginMoveStart();
+  try {
+    await app.fileManager.renameFile(file, newPath);
+
+    let attachmentMoves: AttachmentMoveRecord[] = [];
+    if (attachmentPlans.length > 0) {
+      attachmentMoves = await coMoveAttachmentsAfterNoteRename(app, {
+        plans: attachmentPlans,
+      });
+    }
+
+    historyManager.addEntry({
+      sourcePath: originalPath,
+      destinationPath: newPath,
+      fileName: file.name,
+      attachmentMoves: attachmentMoves.length > 0 ? attachmentMoves : undefined,
+    });
+
+    return attachmentMoves;
+  } finally {
+    historyManager.markPluginMoveEnd();
+  }
+}

--- a/src/application/perform-note-move.ts
+++ b/src/application/perform-note-move.ts
@@ -7,6 +7,7 @@ import {
 } from './co-move-attachments-on-note-move';
 import type { AttachmentMoveSettings } from '../types/PluginData';
 import type { HistoryManager } from '../core/HistoryManager';
+import { deleteEmptyAssetFoldersAfterMove } from '../domain/attachments/delete-empty-asset-folders';
 
 export interface PerformNoteMoveOptions {
   app: App;
@@ -50,6 +51,13 @@ export async function performNoteMove(
       attachmentMoves = await coMoveAttachmentsAfterNoteRename(app, {
         plans: attachmentPlans,
       });
+
+      if (
+        attachmentSettings.deleteEmptyAssetFolders &&
+        attachmentMoves.length > 0
+      ) {
+        await deleteEmptyAssetFoldersAfterMove(app, attachmentMoves);
+      }
     }
 
     historyManager.addEntry({

--- a/src/core/AdvancedNoteMover.ts
+++ b/src/core/AdvancedNoteMover.ts
@@ -3,6 +3,8 @@ import { NoticeManager } from '../utils/NoticeManager';
 import { RuleManagerV2 } from './RuleManagerV2';
 import { createError, handleError } from '../utils/Error';
 import { combinePath, ensureFolderExists } from '../utils/PathUtils';
+import { performNoteMove } from '../application/perform-note-move';
+import { getAttachmentMoveSettings } from '../utils/attachment-settings';
 import AdvancedNoteMoverPlugin from 'main';
 import { type OperationType } from '../types/Common';
 import { MovePreview } from '../types/MovePreview';
@@ -138,19 +140,16 @@ export class AdvancedNoteMover {
             );
           }
 
-          this.plugin.historyManager.markPluginMoveStart();
-
-          try {
-            await app.fileManager.renameFile(file, newPath);
-
-            this.plugin.historyManager.addEntry({
-              sourcePath: originalPath,
-              destinationPath: newPath,
-              fileName: file.name,
-            });
-          } finally {
-            this.plugin.historyManager.markPluginMoveEnd();
-          }
+          await performNoteMove({
+            app,
+            historyManager: this.plugin.historyManager,
+            file,
+            originalPath,
+            newPath,
+            attachmentSettings: getAttachmentMoveSettings(
+              this.plugin.settings.settings
+            ),
+          });
 
           return true;
         } catch (error) {

--- a/src/core/HistoryManager.ts
+++ b/src/core/HistoryManager.ts
@@ -3,7 +3,9 @@ import {
   BulkOperation,
   TimeFilter,
   RetentionPolicy,
+  type AttachmentPathMove,
 } from '../types/HistoryEntry';
+import { TFile } from 'obsidian';
 import AdvancedNoteMoverPlugin from 'main';
 import { createError, handleError } from '../utils/Error';
 import { NoticeManager } from '../utils/NoticeManager';
@@ -291,6 +293,55 @@ export class HistoryManager {
     return now - millisecondsToSubtract;
   }
 
+  /**
+   * Restores co-moved attachments to their original paths (reverse move order).
+   */
+  private async undoAttachmentMoves(
+    attachmentMoves: AttachmentPathMove[] | undefined
+  ): Promise<boolean> {
+    if (!attachmentMoves?.length) {
+      return true;
+    }
+
+    let allOk = true;
+    const reversed = [...attachmentMoves].reverse();
+
+    for (const move of reversed) {
+      const file = this.plugin.app.vault.getAbstractFileByPath(
+        move.destinationPath
+      );
+      if (!(file instanceof TFile)) {
+        console.warn(
+          `[Advanced Note Mover] Attachment undo skipped; not found: ${move.destinationPath}`
+        );
+        allOk = false;
+        continue;
+      }
+
+      const sourceFolder = getParentPath(move.sourcePath);
+      if (
+        sourceFolder &&
+        !(await ensureFolderExists(this.plugin.app, sourceFolder))
+      ) {
+        allOk = false;
+        continue;
+      }
+
+      try {
+        await this.plugin.app.fileManager.renameFile(file, move.sourcePath);
+      } catch (error) {
+        handleError(
+          error,
+          `Error undoing attachment move for ${move.destinationPath}`,
+          false
+        );
+        allOk = false;
+      }
+    }
+
+    return allOk;
+  }
+
   public async undoEntry(entryId: string): Promise<boolean> {
     const entryIndex = this.history.findIndex(entry => entry.id === entryId);
     if (entryIndex === -1) return false;
@@ -326,6 +377,7 @@ export class HistoryManager {
     try {
       this.markPluginMoveStart();
       await this.plugin.app.fileManager.renameFile(file, entry.sourcePath);
+      await this.undoAttachmentMoves(entry.attachmentMoves);
 
       // Remove from individual history
       this.history.splice(entryIndex, 1);
@@ -408,6 +460,7 @@ export class HistoryManager {
       );
       this.markPluginMoveStart();
       await this.plugin.app.fileManager.renameFile(file, entry.sourcePath);
+      await this.undoAttachmentMoves(entry.attachmentMoves);
 
       // Remove the entry from history
       const entryIndex = this.history.findIndex(e => e.id === entry.id);
@@ -548,6 +601,9 @@ export class HistoryManager {
       try {
         this.markPluginMoveStart();
         await this.plugin.app.fileManager.renameFile(file, entry.sourcePath);
+        const attachmentsOk = await this.undoAttachmentMoves(
+          entry.attachmentMoves
+        );
         NoticeManager.success(
           `Successfully moved ${entry.fileName} back to ${entry.sourcePath}`
         );
@@ -558,7 +614,7 @@ export class HistoryManager {
           this.history.splice(historyIndex, 1);
         }
 
-        results.push(true);
+        results.push(attachmentsOk);
       } catch (error) {
         handleError(error, `Error undoing move for ${entry.fileName}`, false);
         results.push(false);

--- a/src/domain/attachments/delete-empty-asset-folders.test.ts
+++ b/src/domain/attachments/delete-empty-asset-folders.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { App } from 'obsidian';
+import {
+  collectSourceFoldersFromMoves,
+  deleteEmptyAssetFoldersAfterMove,
+  sortFoldersByDepthDesc,
+} from './delete-empty-asset-folders';
+
+describe('delete-empty-asset-folders', () => {
+  describe('sortFoldersByDepthDesc', () => {
+    it('orders deeper paths before shallower ones', () => {
+      expect(
+        sortFoldersByDepthDesc([
+          'Folder A',
+          'Folder A/_assets',
+          'Folder A/_assets/thumbs',
+        ])
+      ).toEqual(['Folder A/_assets/thumbs', 'Folder A/_assets', 'Folder A']);
+    });
+  });
+
+  describe('collectSourceFoldersFromMoves', () => {
+    it('returns unique parent folders of moved attachments', () => {
+      const folders = collectSourceFoldersFromMoves([
+        {
+          sourcePath: 'Folder A/_assets/a.png',
+          destinationPath: 'Folder B/_assets/a.png',
+        },
+        {
+          sourcePath: 'Folder A/_assets/b.png',
+          destinationPath: 'Folder B/_assets/b.png',
+        },
+      ]);
+      expect(folders).toEqual(['Folder A/_assets']);
+    });
+  });
+
+  describe('deleteEmptyAssetFoldersAfterMove', () => {
+    it('removes empty source asset folders', async () => {
+      const rmdir = vi.fn().mockResolvedValue(undefined);
+      const list = vi.fn().mockResolvedValue({ files: [], folders: [] });
+      const exists = vi.fn().mockResolvedValue(true);
+
+      const app = {
+        vault: {
+          adapter: { exists, list, rmdir },
+        },
+      } as unknown as App;
+
+      const deleted = await deleteEmptyAssetFoldersAfterMove(app, [
+        {
+          sourcePath: 'Folder A/_assets/a.png',
+          destinationPath: 'Folder B/_assets/a.png',
+        },
+      ]);
+
+      expect(deleted).toEqual(['Folder A/_assets']);
+      expect(rmdir).toHaveBeenCalledWith('Folder A/_assets', false);
+    });
+
+    it('skips folders that still contain files', async () => {
+      const rmdir = vi.fn();
+      const list = vi
+        .fn()
+        .mockResolvedValue({ files: ['other.png'], folders: [] });
+      const exists = vi.fn().mockResolvedValue(true);
+
+      const app = {
+        vault: {
+          adapter: { exists, list, rmdir },
+        },
+      } as unknown as App;
+
+      const deleted = await deleteEmptyAssetFoldersAfterMove(app, [
+        {
+          sourcePath: 'Folder A/_assets/a.png',
+          destinationPath: 'Folder B/_assets/a.png',
+        },
+      ]);
+
+      expect(deleted).toEqual([]);
+      expect(rmdir).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/domain/attachments/delete-empty-asset-folders.ts
+++ b/src/domain/attachments/delete-empty-asset-folders.ts
@@ -1,0 +1,81 @@
+import type { App } from 'obsidian';
+
+export interface AttachmentSourceMove {
+  sourcePath: string;
+  destinationPath: string;
+}
+
+/** Sort folder paths deepest-first so nested empty folders are removed before parents. */
+export function sortFoldersByDepthDesc(folderPaths: string[]): string[] {
+  return [...folderPaths].sort((a, b) => {
+    const depthA = a.split('/').length;
+    const depthB = b.split('/').length;
+    if (depthB !== depthA) {
+      return depthB - depthA;
+    }
+    return b.localeCompare(a);
+  });
+}
+
+/** Unique parent directories of moved attachment source paths. */
+export function collectSourceFoldersFromMoves(
+  moves: AttachmentSourceMove[]
+): string[] {
+  const folders = new Set<string>();
+  for (const move of moves) {
+    const lastSlash = move.sourcePath.lastIndexOf('/');
+    if (lastSlash > 0) {
+      folders.add(move.sourcePath.substring(0, lastSlash));
+    }
+  }
+  return sortFoldersByDepthDesc([...folders]);
+}
+
+export async function isVaultFolderEmpty(
+  app: App,
+  folderPath: string
+): Promise<boolean> {
+  if (!folderPath) {
+    return false;
+  }
+  const exists = await app.vault.adapter.exists(folderPath);
+  if (!exists) {
+    return false;
+  }
+  const listing = await app.vault.adapter.list(folderPath);
+  return listing.files.length === 0 && listing.folders.length === 0;
+}
+
+/**
+ * Deletes vault folders that are empty after attachment co-move.
+ * Only considers folders that previously held moved attachments (deepest first).
+ */
+export async function deleteEmptyAssetFoldersAfterMove(
+  app: App,
+  moves: AttachmentSourceMove[]
+): Promise<string[]> {
+  if (moves.length === 0) {
+    return [];
+  }
+
+  const deleted: string[] = [];
+  const candidates = collectSourceFoldersFromMoves(moves);
+
+  for (const folderPath of candidates) {
+    if (!(await isVaultFolderEmpty(app, folderPath))) {
+      continue;
+    }
+
+    try {
+      await app.vault.adapter.rmdir(folderPath, false);
+      deleted.push(folderPath);
+    } catch (error) {
+      console.warn(
+        `[Advanced Note Mover] Could not delete empty folder ${folderPath}:`,
+        error
+      );
+    }
+  }
+
+  return deleted;
+}

--- a/src/domain/attachments/note-attachments.test.ts
+++ b/src/domain/attachments/note-attachments.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import type { App } from 'obsidian';
+import { TFile } from 'obsidian';
+import {
+  buildAttachmentMovePlans,
+  collectNoteAttachments,
+  computeCoMovedAttachmentPath,
+  isAttachmentUnderNoteFolder,
+  isSharedAttachment,
+} from './note-attachments';
+
+function mockFile(path: string, extension = 'md'): TFile {
+  const file = new TFile();
+  file.path = path;
+  file.name = path.split('/').pop() ?? path;
+  file.extension = extension;
+  return file;
+}
+
+describe('note-attachments', () => {
+  describe('isAttachmentUnderNoteFolder', () => {
+    it('accepts files in note subfolders', () => {
+      expect(
+        isAttachmentUnderNoteFolder('Folder A/_assets/a.png', 'Folder A')
+      ).toBe(true);
+    });
+
+    it('rejects files outside the note folder', () => {
+      expect(
+        isAttachmentUnderNoteFolder('Folder B/_assets/a.png', 'Folder A')
+      ).toBe(false);
+    });
+
+    it('for root notes only accepts root-level attachments', () => {
+      expect(isAttachmentUnderNoteFolder('image.png', '')).toBe(true);
+      expect(isAttachmentUnderNoteFolder('_assets/a.png', '')).toBe(false);
+    });
+  });
+
+  describe('computeCoMovedAttachmentPath', () => {
+    it('preserves relative _assets path when note moves between folders', () => {
+      expect(
+        computeCoMovedAttachmentPath(
+          'Folder A/study.md',
+          'Folder B/study.md',
+          'Folder A/_assets/image1.png'
+        )
+      ).toBe('Folder B/_assets/image1.png');
+    });
+
+    it('returns null for attachments outside the note folder', () => {
+      expect(
+        computeCoMovedAttachmentPath(
+          'Folder A/study.md',
+          'Folder B/study.md',
+          'Folder A/../other/image.png'
+        )
+      ).toBeNull();
+    });
+  });
+
+  describe('isSharedAttachment', () => {
+    it('detects backlinks from other notes', () => {
+      const resolvedLinks = {
+        'Folder A/study.md': { 'Folder A/_assets/a.png': 1 },
+        'Folder C/other.md': { 'Folder A/_assets/a.png': 1 },
+      };
+      expect(
+        isSharedAttachment(
+          resolvedLinks,
+          'Folder A/_assets/a.png',
+          'Folder A/study.md'
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when only the moving note references the file', () => {
+      const resolvedLinks = {
+        'Folder A/study.md': { 'Folder A/_assets/a.png': 1 },
+      };
+      expect(
+        isSharedAttachment(
+          resolvedLinks,
+          'Folder A/_assets/a.png',
+          'Folder A/study.md'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('collectNoteAttachments', () => {
+    it('resolves embeds and links to non-movable files under the note folder', () => {
+      const note = mockFile('Folder A/study.md');
+      const attachment = mockFile('Folder A/_assets/image1.png', 'png');
+
+      const app = {
+        metadataCache: {
+          getFileCache: () => ({
+            links: [],
+            embeds: [{ link: '_assets/image1.png' }],
+          }),
+          getFirstLinkpathDest: (link: string, _source: string) =>
+            link === '_assets/image1.png' ? attachment : null,
+        },
+      } as unknown as App;
+
+      const refs = collectNoteAttachments(app, note);
+      expect(refs).toHaveLength(1);
+      expect(refs[0]!.path).toBe('Folder A/_assets/image1.png');
+    });
+
+    it('skips wiki links to other markdown notes', () => {
+      const note = mockFile('Folder A/study.md');
+      const otherNote = mockFile('Folder A/other.md');
+
+      const app = {
+        metadataCache: {
+          getFileCache: () => ({
+            links: [{ link: 'other' }],
+            embeds: [],
+          }),
+          getFirstLinkpathDest: (link: string) =>
+            link === 'other' ? otherNote : null,
+        },
+      } as unknown as App;
+
+      expect(collectNoteAttachments(app, note)).toHaveLength(0);
+    });
+  });
+
+  describe('buildAttachmentMovePlans', () => {
+    it('builds plans for unshared attachments', () => {
+      const note = mockFile('Folder A/study.md');
+      const attachment = mockFile('Folder A/_assets/a.png', 'png');
+
+      const app = {
+        metadataCache: {
+          getFileCache: () => ({
+            links: [],
+            embeds: [{ link: '_assets/a.png' }],
+          }),
+          getFirstLinkpathDest: (link: string) =>
+            link === '_assets/a.png' ? attachment : null,
+          resolvedLinks: {
+            'Folder A/study.md': { 'Folder A/_assets/a.png': 1 },
+          },
+        },
+      } as unknown as App;
+
+      const plans = buildAttachmentMovePlans(
+        app,
+        note,
+        'Folder A/study.md',
+        'Folder B/study.md',
+        { skipSharedAttachments: true }
+      );
+
+      expect(plans).toHaveLength(1);
+      expect(plans[0]!.destinationPath).toBe('Folder B/_assets/a.png');
+    });
+
+    it('skips shared attachments when configured', () => {
+      const note = mockFile('Folder A/study.md');
+      const attachment = mockFile('Folder A/_assets/a.png', 'png');
+
+      const app = {
+        metadataCache: {
+          getFileCache: () => ({
+            links: [],
+            embeds: [{ link: '_assets/a.png' }],
+          }),
+          getFirstLinkpathDest: (link: string) =>
+            link === '_assets/a.png' ? attachment : null,
+          resolvedLinks: {
+            'Folder A/study.md': { 'Folder A/_assets/a.png': 1 },
+            'Folder C/other.md': { 'Folder A/_assets/a.png': 1 },
+          },
+        },
+      } as unknown as App;
+
+      const plans = buildAttachmentMovePlans(
+        app,
+        note,
+        'Folder A/study.md',
+        'Folder B/study.md',
+        { skipSharedAttachments: true }
+      );
+
+      expect(plans).toHaveLength(0);
+    });
+  });
+});

--- a/src/domain/attachments/note-attachments.ts
+++ b/src/domain/attachments/note-attachments.ts
@@ -1,0 +1,169 @@
+import type { App } from 'obsidian';
+import { TFile } from 'obsidian';
+import { isMovableVaultFile } from '../vault/movable-vault-files';
+import { combinePath, getParentPath } from '../../utils/PathUtils';
+
+export interface AttachmentRef {
+  path: string;
+  file: TFile;
+}
+
+function hasUnsafePathSegments(path: string): boolean {
+  return path.split('/').some(seg => seg === '..' || seg === '.');
+}
+
+export interface AttachmentMovePlan {
+  file: TFile;
+  sourcePath: string;
+  destinationPath: string;
+}
+
+/**
+ * Returns true when attachmentPath lives in the note's folder or a subfolder.
+ * Root-level notes only co-move attachments in the vault root (no slashes).
+ */
+export function isAttachmentUnderNoteFolder(
+  attachmentPath: string,
+  noteFolder: string
+): boolean {
+  if (hasUnsafePathSegments(attachmentPath)) {
+    return false;
+  }
+  if (!noteFolder) {
+    return !attachmentPath.includes('/');
+  }
+  return (
+    attachmentPath === noteFolder || attachmentPath.startsWith(`${noteFolder}/`)
+  );
+}
+
+/**
+ * Computes the destination path for an attachment after its parent note moves,
+ * preserving the path relative to the note folder.
+ */
+export function computeCoMovedAttachmentPath(
+  oldNotePath: string,
+  newNotePath: string,
+  attachmentPath: string
+): string | null {
+  const oldNoteFolder = getParentPath(oldNotePath);
+  const newNoteFolder = getParentPath(newNotePath);
+
+  if (!isAttachmentUnderNoteFolder(attachmentPath, oldNoteFolder)) {
+    return null;
+  }
+
+  const relative = oldNoteFolder
+    ? attachmentPath.slice(oldNoteFolder.length + 1)
+    : attachmentPath;
+
+  return combinePath(newNoteFolder, relative);
+}
+
+/**
+ * True when any note other than excludeNotePath links to attachmentPath.
+ */
+export function isSharedAttachment(
+  resolvedLinks: Record<string, Record<string, number>>,
+  attachmentPath: string,
+  excludeNotePath: string
+): boolean {
+  for (const [sourcePath, dests] of Object.entries(resolvedLinks)) {
+    if (sourcePath === excludeNotePath) {
+      continue;
+    }
+    if (dests[attachmentPath]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Collects vault attachment files referenced by links/embeds in a markdown note.
+ */
+export function collectNoteAttachments(app: App, note: TFile): AttachmentRef[] {
+  if (note.extension !== 'md') {
+    return [];
+  }
+
+  const fileCache = app.metadataCache.getFileCache(note);
+  if (!fileCache) {
+    return [];
+  }
+
+  const linkPaths = new Set<string>();
+  for (const link of fileCache.links ?? []) {
+    if (link.link && typeof link.link === 'string') {
+      linkPaths.add(link.link);
+    }
+  }
+  for (const embed of fileCache.embeds ?? []) {
+    if (embed.link && typeof embed.link === 'string') {
+      linkPaths.add(embed.link);
+    }
+  }
+
+  const noteFolder = getParentPath(note.path);
+  const seen = new Set<string>();
+  const result: AttachmentRef[] = [];
+
+  for (const linkPath of linkPaths) {
+    const resolved = app.metadataCache.getFirstLinkpathDest(
+      linkPath,
+      note.path
+    );
+    if (!resolved || !(resolved instanceof TFile)) {
+      continue;
+    }
+    if (isMovableVaultFile(resolved)) {
+      continue;
+    }
+    if (!isAttachmentUnderNoteFolder(resolved.path, noteFolder)) {
+      continue;
+    }
+    if (seen.has(resolved.path)) {
+      continue;
+    }
+    seen.add(resolved.path);
+    result.push({ path: resolved.path, file: resolved });
+  }
+
+  return result;
+}
+
+/**
+ * Builds move plans for attachments that should co-move with a note.
+ */
+export function buildAttachmentMovePlans(
+  app: App,
+  note: TFile,
+  oldNotePath: string,
+  newNotePath: string,
+  options: { skipSharedAttachments: boolean }
+): AttachmentMovePlan[] {
+  const attachments = collectNoteAttachments(app, note);
+  const plans: AttachmentMovePlan[] = [];
+
+  for (const { file, path } of attachments) {
+    if (
+      options.skipSharedAttachments &&
+      isSharedAttachment(app.metadataCache.resolvedLinks, path, oldNotePath)
+    ) {
+      continue;
+    }
+
+    const destinationPath = computeCoMovedAttachmentPath(
+      oldNotePath,
+      newNotePath,
+      path
+    );
+    if (!destinationPath || destinationPath === path) {
+      continue;
+    }
+
+    plans.push({ file, sourcePath: path, destinationPath });
+  }
+
+  return plans;
+}

--- a/src/infrastructure/persistence/plugin-settings-controller.ts
+++ b/src/infrastructure/persistence/plugin-settings-controller.ts
@@ -105,6 +105,22 @@ export async function validateAndRepairPluginData(
     plugin.settings.settings.enablePerformanceDebug = false;
   }
 
+  if (!plugin.settings.settings.attachments) {
+    plugin.settings.settings.attachments = {
+      moveWithNote: false,
+      skipSharedAttachments: true,
+    };
+  } else {
+    if (plugin.settings.settings.attachments.moveWithNote === undefined) {
+      plugin.settings.settings.attachments.moveWithNote = false;
+    }
+    if (
+      plugin.settings.settings.attachments.skipSharedAttachments === undefined
+    ) {
+      plugin.settings.settings.attachments.skipSharedAttachments = true;
+    }
+  }
+
   if (!Array.isArray(plugin.settings.settings.rulesV2)) {
     plugin.settings.settings.rulesV2 = [];
   }
@@ -212,6 +228,10 @@ export function buildDefaultSettingsData(): SettingsData {
     enableRuleEvaluationCache: true,
     enableVaultIndexCache: true,
     enablePerformanceDebug: false,
+    attachments: {
+      moveWithNote: true,
+      skipSharedAttachments: true,
+    },
   } as SettingsData;
 }
 

--- a/src/infrastructure/persistence/plugin-settings-controller.ts
+++ b/src/infrastructure/persistence/plugin-settings-controller.ts
@@ -109,6 +109,7 @@ export async function validateAndRepairPluginData(
     plugin.settings.settings.attachments = {
       moveWithNote: false,
       skipSharedAttachments: true,
+      deleteEmptyAssetFolders: false,
     };
   } else {
     if (plugin.settings.settings.attachments.moveWithNote === undefined) {
@@ -118,6 +119,11 @@ export async function validateAndRepairPluginData(
       plugin.settings.settings.attachments.skipSharedAttachments === undefined
     ) {
       plugin.settings.settings.attachments.skipSharedAttachments = true;
+    }
+    if (
+      plugin.settings.settings.attachments.deleteEmptyAssetFolders === undefined
+    ) {
+      plugin.settings.settings.attachments.deleteEmptyAssetFolders = false;
     }
   }
 
@@ -231,6 +237,7 @@ export function buildDefaultSettingsData(): SettingsData {
     attachments: {
       moveWithNote: true,
       skipSharedAttachments: true,
+      deleteEmptyAssetFolders: false,
     },
   } as SettingsData;
 }

--- a/src/modals/PreviewModal.ts
+++ b/src/modals/PreviewModal.ts
@@ -5,6 +5,8 @@ import { NoticeManager } from '../utils/NoticeManager';
 import { MobileUtils } from '../utils/MobileUtils';
 import { combinePath, ensureFolderExists } from '../utils/PathUtils';
 import { handleError, createError } from '../utils/Error';
+import { performNoteMove } from '../application/perform-note-move';
+import { getAttachmentMoveSettings } from '../utils/attachment-settings';
 import { BaseModal, BaseModalOptions } from './BaseModal';
 
 export class PreviewModal extends BaseModal {
@@ -253,18 +255,17 @@ export class PreviewModal extends BaseModal {
             );
           }
 
-          this.plugin.historyManager.markPluginMoveStart();
-          try {
-            await this.app.fileManager.renameFile(file, newPath);
-            this.plugin.historyManager.addEntry({
-              sourcePath: entry.currentPath,
-              destinationPath: newPath,
-              fileName: file.name,
-            });
-            movedCount++;
-          } finally {
-            this.plugin.historyManager.markPluginMoveEnd();
-          }
+          await performNoteMove({
+            app: this.app,
+            historyManager: this.plugin.historyManager,
+            file,
+            originalPath: entry.currentPath,
+            newPath,
+            attachmentSettings: getAttachmentMoveSettings(
+              this.plugin.settings.settings
+            ),
+          });
+          movedCount++;
         } catch (error) {
           handleError(error, `Error moving file ${entry.fileName}`, false);
           errorCount++;

--- a/src/settings/sections/PeriodicMovementSettingsSection.ts
+++ b/src/settings/sections/PeriodicMovementSettingsSection.ts
@@ -121,6 +121,8 @@ export class TriggerSettingsSection {
       }
     }
 
+    this.addAttachmentMoveSettings(isMobile);
+
     if (this.plugin.settings.settings.triggers.enablePeriodicMovement) {
       const intervalSetting = new Setting(this.containerEl)
         .setName('Periodic movement interval')
@@ -180,6 +182,61 @@ export class TriggerSettingsSection {
             'advancedNoteMover-mobile-text-input'
           );
         }
+      }
+    }
+  }
+
+  private addAttachmentMoveSettings(isMobile: boolean): void {
+    if (!this.plugin.settings.settings.attachments) {
+      this.plugin.settings.settings.attachments = {
+        moveWithNote: false,
+        skipSharedAttachments: true,
+      };
+    }
+
+    const attachments = this.plugin.settings.settings.attachments;
+
+    const moveWithNoteDesc =
+      'When a markdown note is moved, also move images and other attachments referenced in the note that live in the note folder or its subfolders (e.g. _assets/). Relative link structure is preserved.';
+
+    const moveWithNoteSetting = new Setting(this.containerEl)
+      .setName('Move attachments with note')
+      .setDesc(moveWithNoteDesc)
+      .addToggle(toggle =>
+        toggle
+          .setValue(attachments.moveWithNote === true)
+          .onChange(async value => {
+            attachments.moveWithNote = value;
+            await this.plugin.save_settings();
+            this.refreshDisplay();
+          })
+      );
+
+    if (isMobile) {
+      moveWithNoteSetting.settingEl.addClass(
+        'advancedNoteMover-mobile-optimized'
+      );
+    }
+
+    if (attachments.moveWithNote) {
+      const skipSharedSetting = new Setting(this.containerEl)
+        .setName('Skip shared attachments')
+        .setDesc(
+          'Do not move attachment files that are also linked from other notes. Prevents breaking references elsewhere in the vault.'
+        )
+        .addToggle(toggle =>
+          toggle
+            .setValue(attachments.skipSharedAttachments !== false)
+            .onChange(async value => {
+              attachments.skipSharedAttachments = value;
+              await this.plugin.save_settings();
+            })
+        );
+
+      if (isMobile) {
+        skipSharedSetting.settingEl.addClass(
+          'advancedNoteMover-mobile-optimized'
+        );
       }
     }
   }

--- a/src/settings/sections/PeriodicMovementSettingsSection.ts
+++ b/src/settings/sections/PeriodicMovementSettingsSection.ts
@@ -191,6 +191,7 @@ export class TriggerSettingsSection {
       this.plugin.settings.settings.attachments = {
         moveWithNote: false,
         skipSharedAttachments: true,
+        deleteEmptyAssetFolders: false,
       };
     }
 
@@ -235,6 +236,26 @@ export class TriggerSettingsSection {
 
       if (isMobile) {
         skipSharedSetting.settingEl.addClass(
+          'advancedNoteMover-mobile-optimized'
+        );
+      }
+
+      const deleteEmptySetting = new Setting(this.containerEl)
+        .setName('Delete empty asset folders')
+        .setDesc(
+          'After moving attachments, remove source folders (such as _assets) that no longer contain any files.'
+        )
+        .addToggle(toggle =>
+          toggle
+            .setValue(attachments.deleteEmptyAssetFolders === true)
+            .onChange(async value => {
+              attachments.deleteEmptyAssetFolders = value;
+              await this.plugin.save_settings();
+            })
+        );
+
+      if (isMobile) {
+        deleteEmptySetting.settingEl.addClass(
           'advancedNoteMover-mobile-optimized'
         );
       }

--- a/src/types/HistoryEntry.ts
+++ b/src/types/HistoryEntry.ts
@@ -1,3 +1,8 @@
+export interface AttachmentPathMove {
+  sourcePath: string;
+  destinationPath: string;
+}
+
 export interface HistoryEntry {
   id: string;
   sourcePath: string;
@@ -6,6 +11,8 @@ export interface HistoryEntry {
   fileName: string;
   bulkOperationId?: string; // Groups entries that belong to the same bulk operation
   operationType?: 'single' | 'bulk' | 'periodic'; // Type of operation
+  /** Attachment files co-moved with this note (for undo). */
+  attachmentMoves?: AttachmentPathMove[];
 }
 
 export interface BulkOperation {

--- a/src/types/PluginData.ts
+++ b/src/types/PluginData.ts
@@ -14,6 +14,8 @@ export interface PluginData {
 export interface AttachmentMoveSettings {
   moveWithNote: boolean;
   skipSharedAttachments: boolean;
+  /** Remove attachment source folders (e.g. _assets) when empty after a co-move. */
+  deleteEmptyAssetFolders: boolean;
 }
 
 export interface SettingsData {

--- a/src/types/PluginData.ts
+++ b/src/types/PluginData.ts
@@ -11,6 +11,11 @@ export interface PluginData {
   schemaVersion?: number;
 }
 
+export interface AttachmentMoveSettings {
+  moveWithNote: boolean;
+  skipSharedAttachments: boolean;
+}
+
 export interface SettingsData {
   triggers: TriggerSettings;
   filters: FilterSettings;
@@ -21,6 +26,7 @@ export interface SettingsData {
   enableVaultIndexCache?: boolean;
   /** When true, records timing spans and logs `[Advanced Note Mover perf]` to the console. */
   enablePerformanceDebug?: boolean;
+  attachments?: AttachmentMoveSettings;
 }
 
 export interface HistoryData {

--- a/src/utils/attachment-settings.ts
+++ b/src/utils/attachment-settings.ts
@@ -1,0 +1,20 @@
+import type { SettingsData, AttachmentMoveSettings } from '../types/PluginData';
+
+const DEFAULT_ATTACHMENT_SETTINGS: AttachmentMoveSettings = {
+  moveWithNote: true,
+  skipSharedAttachments: true,
+};
+
+/** Resolves attachment co-move settings with defaults. */
+export function getAttachmentMoveSettings(
+  settings: SettingsData
+): AttachmentMoveSettings {
+  const attachments = settings.attachments;
+  return {
+    moveWithNote:
+      attachments?.moveWithNote ?? DEFAULT_ATTACHMENT_SETTINGS.moveWithNote,
+    skipSharedAttachments:
+      attachments?.skipSharedAttachments ??
+      DEFAULT_ATTACHMENT_SETTINGS.skipSharedAttachments,
+  };
+}

--- a/src/utils/attachment-settings.ts
+++ b/src/utils/attachment-settings.ts
@@ -3,6 +3,7 @@ import type { SettingsData, AttachmentMoveSettings } from '../types/PluginData';
 const DEFAULT_ATTACHMENT_SETTINGS: AttachmentMoveSettings = {
   moveWithNote: true,
   skipSharedAttachments: true,
+  deleteEmptyAssetFolders: false,
 };
 
 /** Resolves attachment co-move settings with defaults. */
@@ -16,5 +17,8 @@ export function getAttachmentMoveSettings(
     skipSharedAttachments:
       attachments?.skipSharedAttachments ??
       DEFAULT_ATTACHMENT_SETTINGS.skipSharedAttachments,
+    deleteEmptyAssetFolders:
+      attachments?.deleteEmptyAssetFolders ??
+      DEFAULT_ATTACHMENT_SETTINGS.deleteEmptyAssetFolders,
   };
 }


### PR DESCRIPTION
- Added functionality to remove source folders that are empty after moving attachments, enhancing file management.
- Introduced a new setting to enable or disable this feature, with defaults set for new installations.
- Updated relevant functions and tests to ensure proper integration and reliability of the new feature.

Closes #77 
