### PR TITLE
chore: update release workflow to include permissions and attest release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v3
@@ -21,6 +25,13 @@ jobs:
         run: |
           npm install
           npm run build
+
+      - name: Attest release assets
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            main.js
+            styles.css
 
       - name: Create release
         env:


### PR DESCRIPTION
Added permissions for contents, id-token, and attestations in the GitHub Actions workflow. Included a step to attest release assets for main.js and styles.css.