### PR TITLE
fix: Add move confirmation toasts for single-file moves (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.4](https://github.com/bueckerlars/obsidian-note-mover-shortcut/compare/1.0.3...1.0.4)
+
+### Improvements
+
+- **Move confirmation toasts** ([#86](https://github.com/bueckerlars/obsidian-note-mover-shortcut/issues/86)): Single-file moves (command, ribbon icon, and on-edit trigger) now show a success notice when a note is actually moved, e.g. `"My Note" moved to tasks/personal`. No toast when no rule matched or the file was already in the target folder.
+
 ## [1.0.3](https://github.com/bueckerlars/obsidian-note-mover-shortcut/compare/1.0.2...1.0.3)
 
 ### Fixes

--- a/src/application/move-file-service.ts
+++ b/src/application/move-file-service.ts
@@ -1,5 +1,6 @@
 import type { TFile } from 'obsidian';
 import type AdvancedNoteMoverPlugin from 'main';
+import type { FileMoveResult } from '../types/Common';
 
 /**
  * Application use-case: move files using configured rules (delegates to core).
@@ -15,7 +16,7 @@ export class MoveFileService {
     file: TFile,
     defaultFolder: string,
     skipFilter = false
-  ): Promise<boolean> {
+  ): Promise<FileMoveResult> {
     return this.plugin.advancedNoteMover.moveFileBasedOnTags(
       file,
       defaultFolder,

--- a/src/core/AdvancedNoteMover.ts
+++ b/src/core/AdvancedNoteMover.ts
@@ -6,7 +6,8 @@ import { combinePath, ensureFolderExists } from '../utils/PathUtils';
 import { performNoteMove } from '../application/perform-note-move';
 import { getAttachmentMoveSettings } from '../utils/attachment-settings';
 import AdvancedNoteMoverPlugin from 'main';
-import { type OperationType } from '../types/Common';
+import { type FileMoveResult, type OperationType } from '../types/Common';
+import { showSingleFileMoveNotice } from '../utils/single-file-move-notice';
 import { MovePreview } from '../types/MovePreview';
 import {
   SETTINGS_CONSTANTS,
@@ -15,8 +16,12 @@ import {
 
 const BULK_CHUNK_SIZE = 50;
 
+const MOVE_NOTICE_DEDUPE_MS = 3000;
+
 export class AdvancedNoteMover {
   private ruleManagerV2: RuleManagerV2;
+  private readonly filesMoveInFlight = new Set<string>();
+  private readonly lastMoveNoticeAtByFileName = new Map<string, number>();
 
   constructor(private plugin: AdvancedNoteMoverPlugin) {
     this.ruleManagerV2 = new RuleManagerV2(
@@ -85,7 +90,7 @@ export class AdvancedNoteMover {
     file: TFile,
     defaultFolder: string,
     skipFilter = false
-  ): Promise<boolean> {
+  ): Promise<FileMoveResult> {
     return this.plugin.performanceTrace.recordAsync(
       'AdvancedNoteMover.moveFileBasedOnTags',
       async () => {
@@ -96,16 +101,21 @@ export class AdvancedNoteMover {
         const originalPath = file.path;
         const mtime = file.stat?.mtime ?? 0;
 
+        if (this.filesMoveInFlight.has(originalPath)) {
+          return { moved: false };
+        }
+        this.filesMoveInFlight.add(originalPath);
+
         // Fast path: if the cache is enabled and already knows the result for
         // this file, skip the expensive rule evaluation entirely.
         if (cacheEnabled && !cache.needsEvaluation(originalPath, mtime)) {
           const cachedDest = cache.getCachedDestination(originalPath);
           if (cachedDest === null || cachedDest === undefined) {
-            return false; // No rule matched last time and nothing changed
+            return this.finishFileMove(originalPath, file, { moved: false });
           }
           const cachedPath = combinePath(cachedDest, file.name);
           if (originalPath === cachedPath) {
-            return false; // Already in correct folder
+            return this.finishFileMove(originalPath, file, { moved: false });
           }
         }
 
@@ -124,14 +134,14 @@ export class AdvancedNoteMover {
           }
 
           if (result === null) {
-            return false;
+            return this.finishFileMove(originalPath, file, { moved: false });
           }
           targetFolder = result;
 
           const newPath = combinePath(targetFolder, file.name);
 
           if (originalPath === newPath) {
-            return false;
+            return this.finishFileMove(originalPath, file, { moved: false });
           }
 
           if (!(await ensureFolderExists(app, targetFolder))) {
@@ -151,10 +161,12 @@ export class AdvancedNoteMover {
             ),
           });
 
-          return true;
+          const moveResult = { moved: true, targetFolder } as const;
+          this.maybeNotifySingleFileMove(file, targetFolder);
+          return this.finishFileMove(originalPath, file, moveResult);
         } catch (error) {
           handleError(error, `Error moving file '${file.path}'`);
-          return false;
+          return this.finishFileMove(originalPath, file, { moved: false });
         }
       },
       { path: file.path, skipFilter }
@@ -194,8 +206,8 @@ export class AdvancedNoteMover {
               break;
             }
             try {
-              const wasMoved = await this.moveFileBasedOnTags(files[i], '/');
-              if (wasMoved) {
+              const moveResult = await this.moveFileBasedOnTags(files[i], '/');
+              if (moveResult.moved) {
                 successCount++;
               }
             } catch (error) {
@@ -306,40 +318,35 @@ export class AdvancedNoteMover {
     }
 
     try {
-      // Move file using rules and filters
       await this.moveFileBasedOnTags(file, '/', false);
-
-      // Create notice with undo button
-      NoticeManager.showWithUndo(
-        'info',
-        `Note "${file.name}" has been moved`,
-        async () => {
-          try {
-            NoticeManager.info(
-              `Attempting to undo move for file: ${file.name}`
-            );
-            const success = await this.plugin.historyManager.undoLastMove(
-              file.name
-            );
-            if (success) {
-              NoticeManager.success(`Note "${file.name}" has been moved back`, {
-                duration: 3000,
-              });
-            } else {
-              NoticeManager.warning(`Could not undo move for "${file.name}"`, {
-                duration: 3000,
-              });
-            }
-          } catch (error) {
-            handleError(error, 'Error in undo button click handler', false);
-          }
-        },
-        'Undo'
-      );
     } catch (error) {
       handleError(error, 'moveFocusedNoteToDestination', false);
       return;
     }
+  }
+
+  private finishFileMove(
+    originalPath: string,
+    file: TFile,
+    result: FileMoveResult
+  ): FileMoveResult {
+    this.filesMoveInFlight.delete(originalPath);
+    this.filesMoveInFlight.delete(file.path);
+    return result;
+  }
+
+  private maybeNotifySingleFileMove(file: TFile, targetFolder: string): void {
+    if (this.plugin.historyManager.isBulkOperationInProgress()) {
+      return;
+    }
+
+    const now = Date.now();
+    const lastAt = this.lastMoveNoticeAtByFileName.get(file.name);
+    if (lastAt !== undefined && now - lastAt < MOVE_NOTICE_DEDUPE_MS) {
+      return;
+    }
+    this.lastMoveNoticeAtByFileName.set(file.name, now);
+    showSingleFileMoveNotice(file, targetFolder);
   }
 
   /**

--- a/src/core/HistoryManager.ts
+++ b/src/core/HistoryManager.ts
@@ -107,6 +107,16 @@ export class HistoryManager {
     this.isPluginMove = false;
   }
 
+  /** True while the plugin is performing a rename (suppress duplicate on-edit work). */
+  public isPluginMoveInProgress(): boolean {
+    return this.isPluginMove;
+  }
+
+  /** True during bulk or periodic vault-wide move loops. */
+  public isBulkOperationInProgress(): boolean {
+    return this.currentBulkOperationId !== null;
+  }
+
   /**
    * Adds a history entry, but only if it's not an internal plugin move
    */

--- a/src/core/TriggerEventHandler.ts
+++ b/src/core/TriggerEventHandler.ts
@@ -1,3 +1,4 @@
+import type { EventRef } from 'obsidian';
 import { TFile } from 'obsidian';
 import AdvancedNoteMoverPlugin from 'main';
 import { DebounceManager } from '../utils/DebounceManager';
@@ -5,7 +6,7 @@ import { isMovableVaultFile } from '../domain/vault/movable-vault-files';
 
 export class TriggerEventHandler {
   private periodicIntervalId: number | null = null;
-  private onEditUnregister: (() => void) | null = null;
+  private onModifyEventRef: EventRef | null = null;
   private debounceManager: DebounceManager;
   private debouncedHandleOnEdit: (file: TFile) => void;
 
@@ -44,26 +45,20 @@ export class TriggerEventHandler {
   }
 
   public toggleOnEditListener(): void {
-    // Unregister existing listener
-    if (this.onEditUnregister) {
-      this.onEditUnregister();
-      this.onEditUnregister = null;
+    if (this.onModifyEventRef) {
+      this.plugin.app.vault.offref(this.onModifyEventRef);
+      this.onModifyEventRef = null;
     }
 
-    // Cancel any pending debounced operations
     this.debounceManager.cancel('onEdit');
 
     if (this.plugin.settings.settings.triggers.enableOnEditTrigger) {
-      this.plugin.registerEvent(
-        this.plugin.app.vault.on('modify', async file => {
-          if (file instanceof TFile && isMovableVaultFile(file)) {
-            // Use debounced handler to prevent excessive processing
-            this.debouncedHandleOnEdit(file);
-          }
-        })
-      );
-      // For testing purposes, we'll store a mock function
-      this.onEditUnregister = () => {};
+      this.onModifyEventRef = this.plugin.app.vault.on('modify', file => {
+        if (file instanceof TFile && isMovableVaultFile(file)) {
+          this.debouncedHandleOnEdit(file);
+        }
+      });
+      this.plugin.registerEvent(this.onModifyEventRef);
     }
   }
 
@@ -77,6 +72,10 @@ export class TriggerEventHandler {
    * @param file - The specific TFile that was modified
    */
   private async handleOnEdit(file: TFile): Promise<void> {
+    if (this.plugin.historyManager.isPluginMoveInProgress()) {
+      return;
+    }
+
     if (this.plugin.settings.settings.enableRuleEvaluationCache !== false) {
       // Ensure the file is marked dirty so the cache check re-evaluates it.
       // The vault event listener in main.ts does the same, but listener

--- a/src/types/Common.ts
+++ b/src/types/Common.ts
@@ -11,6 +11,11 @@ export type NotificationType =
 
 export type OperationType = 'single' | 'bulk' | 'periodic';
 
+/** Result of attempting to move one file via rules. */
+export type FileMoveResult =
+  | { moved: false }
+  | { moved: true; targetFolder: string };
+
 /**
  * Complete metadata extracted from a file for rule matching and processing
  */

--- a/src/utils/single-file-move-notice.test.ts
+++ b/src/utils/single-file-move-notice.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatDestinationFolderForNotice,
+  formatSingleFileMoveMessage,
+} from './single-file-move-notice';
+
+describe('single-file-move-notice', () => {
+  it('formats root destination', () => {
+    expect(formatDestinationFolderForNotice('/')).toBe('/');
+    expect(formatDestinationFolderForNotice('')).toBe('/');
+  });
+
+  it('normalizes trailing slashes', () => {
+    expect(formatDestinationFolderForNotice('tasks/personal/')).toBe(
+      'tasks/personal'
+    );
+  });
+
+  it('builds move message with note title and folder', () => {
+    expect(formatSingleFileMoveMessage('My Note', 'tasks/personal')).toBe(
+      '"My Note" moved to tasks/personal'
+    );
+  });
+});

--- a/src/utils/single-file-move-notice.ts
+++ b/src/utils/single-file-move-notice.ts
@@ -1,0 +1,33 @@
+import type { TFile } from 'obsidian';
+import { NoticeManager } from './NoticeManager';
+
+/** Vault-relative folder path for display in move toasts. */
+export function formatDestinationFolderForNotice(targetFolder: string): string {
+  const normalized = targetFolder
+    .replace(/\\/g, '/')
+    .replace(/\/+$/, '')
+    .trim();
+  if (!normalized || normalized === '/') {
+    return '/';
+  }
+  return normalized;
+}
+
+export function formatSingleFileMoveMessage(
+  displayName: string,
+  targetFolder: string
+): string {
+  return `"${displayName}" moved to ${formatDestinationFolderForNotice(targetFolder)}`;
+}
+
+/**
+ * Toast for a single note move (manual command, ribbon, or on-edit).
+ */
+export function showSingleFileMoveNotice(
+  file: TFile,
+  targetFolder: string
+): void {
+  NoticeManager.success(
+    formatSingleFileMoveMessage(file.basename, targetFolder)
+  );
+}


### PR DESCRIPTION
## Summary

Closes #86

Adds confirmation feedback when a single note is moved by rules:

- Toast format: `"Note Title" moved to folder/path` with **Undo**
- Applies to: command, ribbon icon, and on-edit trigger
- No toast when the file was not moved (no matching rule or already in target folder)
- Bulk/periodic moves keep existing aggregate toasts only

Also fixes duplicate notifications (one with undo, one without) by centralizing the toast in `moveFileBasedOnTags`, guarding concurrent moves, deduplicating notices within 3s, skipping on-edit while a plugin move is in progress, and correctly unregistering the vault `modify` listener when toggling on-edit in settings.