### PR TITLE
fix: show release notes only after plugin update (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.0.5](https://github.com/bueckerlars/obsidian-note-mover-shortcut/compare/1.0.4...1.0.5)
+
+### Fixes
+
+- **Release notes on every startup** ([#92](https://github.com/bueckerlars/obsidian-note-mover-shortcut/issues/92)): The update changelog modal no longer opens on every Obsidian start when `lastSeenVersion` was missing or stored only under `settings`. It now appears only after the installed plugin version is newer than the last seen version. Legacy `lastSeenVersion` values nested in `settings` are migrated to the root `PluginData` field and saved immediately so the migration does not repeat on each load.
+
+### Improvements
+
+- **Show release notes after plugin update** ([#92](https://github.com/bueckerlars/obsidian-note-mover-shortcut/issues/92)): New toggle under **Settings → Updates** (on by default). Turn it off to skip the changelog modal after updates; the plugin still records the current version quietly.
+
 ## [1.0.4](https://github.com/bueckerlars/obsidian-note-mover-shortcut/compare/1.0.3...1.0.4)
 
 ### Improvements

--- a/src/core/UpdateManager.ts
+++ b/src/core/UpdateManager.ts
@@ -2,6 +2,10 @@ import AdvancedNoteMoverPlugin from 'main';
 import { UpdateModal } from '../modals/UpdateModal';
 import { NoticeManager } from '../utils/NoticeManager';
 import { ChangelogEntry, CHANGELOG_ENTRIES } from '../generated/changelog';
+import {
+  isNewerVersion,
+  shouldOfferReleaseNotes,
+} from '../utils/version-compare';
 
 export class UpdateManager {
   private plugin: AdvancedNoteMoverPlugin;
@@ -11,18 +15,23 @@ export class UpdateManager {
   }
 
   /**
-   * Checks if the plugin has been updated and shows the UpdateModal
+   * Checks if the plugin has been updated and shows the UpdateModal when appropriate.
    */
   async checkForUpdates(): Promise<void> {
     const currentVersion = this.plugin.manifest.version;
-    const lastSeenVersion = this.plugin.settings.lastSeenVersion;
+    const lastSeenVersion = this.getLastSeenVersion();
 
-    // On first start or when a new version is detected
-    if (
-      !lastSeenVersion ||
-      this.isNewerVersion(currentVersion, lastSeenVersion)
-    ) {
-      await this.showUpdateModal();
+    if (shouldOfferReleaseNotes(lastSeenVersion, currentVersion)) {
+      if (this.isReleaseNotesEnabled()) {
+        await this.showUpdateModal();
+      } else {
+        await this.markVersionSeen(currentVersion);
+      }
+      return;
+    }
+
+    if (!lastSeenVersion?.trim()) {
+      await this.markVersionSeen(currentVersion);
     }
   }
 
@@ -32,7 +41,7 @@ export class UpdateManager {
    */
   async showUpdateModal(forceShow = false): Promise<void> {
     const currentVersion = this.plugin.manifest.version;
-    let lastSeenVersion = this.plugin.settings.lastSeenVersion;
+    let lastSeenVersion = this.getLastSeenVersion();
 
     // For manual invocation (forceShow), use an older version as base,
     // to ensure relevant information is displayed
@@ -57,36 +66,21 @@ export class UpdateManager {
 
     // Only mark version as "seen" on automatic call
     if (!forceShow) {
-      this.plugin.settings.lastSeenVersion = currentVersion;
-      await this.plugin.save_settings();
+      await this.markVersionSeen(currentVersion);
     }
   }
 
-  /**
-   * Compares two version strings
-   * @param current The current version
-   * @param last The last seen version
-   * @returns true if current is newer than last
-   */
-  private isNewerVersion(current: string, last: string): boolean {
-    const parseVersion = (version: string): number[] => {
-      return version.split('.').map(v => parseInt(v) || 0);
-    };
+  private isReleaseNotesEnabled(): boolean {
+    return this.plugin.settings.settings.showReleaseNotesOnUpdate !== false;
+  }
 
-    const currentParts = parseVersion(current);
-    const lastParts = parseVersion(last);
+  private getLastSeenVersion(): string | undefined {
+    return this.plugin.settings.lastSeenVersion;
+  }
 
-    // Ensure same length for comparison
-    const maxLength = Math.max(currentParts.length, lastParts.length);
-    while (currentParts.length < maxLength) currentParts.push(0);
-    while (lastParts.length < maxLength) lastParts.push(0);
-
-    for (let i = 0; i < maxLength; i++) {
-      if (currentParts[i] > lastParts[i]) return true;
-      if (currentParts[i] < lastParts[i]) return false;
-    }
-
-    return false; // Versions are equal
+  private async markVersionSeen(version: string): Promise<void> {
+    this.plugin.settings.lastSeenVersion = version;
+    await this.plugin.save_settings();
   }
 
   /**
@@ -169,8 +163,8 @@ export class UpdateManager {
 
     // Version must be between fromVersion (exclusive) and toVersion (inclusive)
     return (
-      this.isNewerVersion(version, fromVersion) &&
-      (version === toVersion || this.isNewerVersion(toVersion, version))
+      isNewerVersion(version, fromVersion) &&
+      (version === toVersion || isNewerVersion(toVersion, version))
     );
   }
 }

--- a/src/infrastructure/persistence/plugin-settings-controller.ts
+++ b/src/infrastructure/persistence/plugin-settings-controller.ts
@@ -117,6 +117,7 @@ export async function validateAndRepairPluginData(
       plugin.settings.lastSeenVersion = nestedLastSeen.trim();
       delete (plugin.settings.settings as { lastSeenVersion?: string })
         .lastSeenVersion;
+      await savePersistedSettings(plugin);
     }
   }
 

--- a/src/infrastructure/persistence/plugin-settings-controller.ts
+++ b/src/infrastructure/persistence/plugin-settings-controller.ts
@@ -105,6 +105,21 @@ export async function validateAndRepairPluginData(
     plugin.settings.settings.enablePerformanceDebug = false;
   }
 
+  if (plugin.settings.settings.showReleaseNotesOnUpdate === undefined) {
+    plugin.settings.settings.showReleaseNotesOnUpdate = true;
+  }
+
+  if (!plugin.settings.lastSeenVersion) {
+    const nestedLastSeen = (
+      plugin.settings.settings as { lastSeenVersion?: string }
+    ).lastSeenVersion;
+    if (typeof nestedLastSeen === 'string' && nestedLastSeen.trim() !== '') {
+      plugin.settings.lastSeenVersion = nestedLastSeen.trim();
+      delete (plugin.settings.settings as { lastSeenVersion?: string })
+        .lastSeenVersion;
+    }
+  }
+
   if (!plugin.settings.settings.attachments) {
     plugin.settings.settings.attachments = {
       moveWithNote: false,
@@ -234,6 +249,7 @@ export function buildDefaultSettingsData(): SettingsData {
     enableRuleEvaluationCache: true,
     enableVaultIndexCache: true,
     enablePerformanceDebug: false,
+    showReleaseNotesOnUpdate: true,
     attachments: {
       moveWithNote: true,
       skipSharedAttachments: true,

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -8,6 +8,7 @@ import {
   HistorySettingsSection,
   ImportExportSettingsSection,
   PerformanceDebugSettingsSection,
+  UpdateSettingsSection,
 } from './sections';
 import { DebounceManager } from '../utils/DebounceManager';
 import { MobileUtils } from '../utils/MobileUtils';
@@ -20,6 +21,7 @@ export class AdvancedNoteMoverSettingsTab extends PluginSettingTab {
   private historySettings: HistorySettingsSection;
   private importExportSettings: ImportExportSettingsSection;
   private performanceDebugSettings: PerformanceDebugSettingsSection;
+  private updateSettings: UpdateSettingsSection;
   private debounceManager: DebounceManager;
 
   constructor(private plugin: AdvancedNoteMoverPlugin) {
@@ -67,6 +69,7 @@ export class AdvancedNoteMoverSettingsTab extends PluginSettingTab {
       this.containerEl,
       debouncedDisplay
     );
+    this.updateSettings = new UpdateSettingsSection(plugin, this.containerEl);
   }
 
   display(): void {
@@ -129,6 +132,10 @@ export class AdvancedNoteMoverSettingsTab extends PluginSettingTab {
       this.containerEl,
       debouncedDisplay
     );
+    this.updateSettings = new UpdateSettingsSection(
+      this.plugin,
+      this.containerEl
+    );
 
     this.periodicMovementSettings.addTriggerSettings();
 
@@ -145,6 +152,8 @@ export class AdvancedNoteMoverSettingsTab extends PluginSettingTab {
     this.importExportSettings.addImportExportSettings();
 
     this.performanceDebugSettings.addPerformanceDebugSettings();
+
+    this.updateSettings.addUpdateSettings();
   }
 
   /**

--- a/src/settings/sections/UpdateSettingsSection.ts
+++ b/src/settings/sections/UpdateSettingsSection.ts
@@ -1,0 +1,29 @@
+import AdvancedNoteMoverPlugin from 'main';
+import { Setting } from 'obsidian';
+
+export class UpdateSettingsSection {
+  constructor(
+    private plugin: AdvancedNoteMoverPlugin,
+    private containerEl: HTMLElement
+  ) {}
+
+  addUpdateSettings(): void {
+    new Setting(this.containerEl).setName('Updates').setHeading();
+
+    new Setting(this.containerEl)
+      .setName('Show release notes after plugin update')
+      .setDesc(
+        'When enabled, opens the changelog modal once after you install a newer plugin version. Does not show on every Obsidian startup.'
+      )
+      .addToggle(toggle =>
+        toggle
+          .setValue(
+            this.plugin.settings.settings.showReleaseNotesOnUpdate !== false
+          )
+          .onChange(async value => {
+            this.plugin.settings.settings.showReleaseNotesOnUpdate = value;
+            await this.plugin.save_settings();
+          })
+      );
+  }
+}

--- a/src/settings/sections/index.ts
+++ b/src/settings/sections/index.ts
@@ -5,3 +5,4 @@ export { RulesSettingsSection } from './RulesSettingsSection';
 export { HistorySettingsSection } from './HistorySettingsSection';
 export { ImportExportSettingsSection } from './ImportExportSettingsSection';
 export { PerformanceDebugSettingsSection } from './PerformanceDebugSettingsSection';
+export { UpdateSettingsSection } from './UpdateSettingsSection';

--- a/src/types/PluginData.ts
+++ b/src/types/PluginData.ts
@@ -28,6 +28,8 @@ export interface SettingsData {
   enableVaultIndexCache?: boolean;
   /** When true, records timing spans and logs `[Advanced Note Mover perf]` to the console. */
   enablePerformanceDebug?: boolean;
+  /** When true (default), show the changelog modal once after a plugin version update. */
+  showReleaseNotesOnUpdate?: boolean;
   attachments?: AttachmentMoveSettings;
 }
 

--- a/src/utils/version-compare.test.ts
+++ b/src/utils/version-compare.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isNewerVersion, shouldOfferReleaseNotes } from './version-compare';
+
+describe('version-compare', () => {
+  describe('isNewerVersion', () => {
+    it('returns true when current is newer', () => {
+      expect(isNewerVersion('1.0.4', '1.0.3')).toBe(true);
+      expect(isNewerVersion('1.1.0', '1.0.9')).toBe(true);
+    });
+
+    it('returns false when versions are equal', () => {
+      expect(isNewerVersion('1.0.4', '1.0.4')).toBe(false);
+    });
+
+    it('returns false when current is older', () => {
+      expect(isNewerVersion('1.0.3', '1.0.4')).toBe(false);
+    });
+  });
+
+  describe('shouldOfferReleaseNotes', () => {
+    it('returns false without a stored last seen version', () => {
+      expect(shouldOfferReleaseNotes(undefined, '1.0.4')).toBe(false);
+      expect(shouldOfferReleaseNotes('', '1.0.4')).toBe(false);
+      expect(shouldOfferReleaseNotes('  ', '1.0.4')).toBe(false);
+    });
+
+    it('returns true only after a version bump', () => {
+      expect(shouldOfferReleaseNotes('1.0.3', '1.0.4')).toBe(true);
+      expect(shouldOfferReleaseNotes('1.0.4', '1.0.4')).toBe(false);
+    });
+  });
+});

--- a/src/utils/version-compare.ts
+++ b/src/utils/version-compare.ts
@@ -1,0 +1,36 @@
+/**
+ * Compares two semver-like version strings (major.minor.patch).
+ * @returns true if current is strictly newer than last
+ */
+export function isNewerVersion(current: string, last: string): boolean {
+  const parseVersion = (version: string): number[] => {
+    return version.split('.').map(v => parseInt(v, 10) || 0);
+  };
+
+  const currentParts = parseVersion(current);
+  const lastParts = parseVersion(last);
+
+  const maxLength = Math.max(currentParts.length, lastParts.length);
+  while (currentParts.length < maxLength) currentParts.push(0);
+  while (lastParts.length < maxLength) lastParts.push(0);
+
+  for (let i = 0; i < maxLength; i++) {
+    if (currentParts[i] > lastParts[i]) return true;
+    if (currentParts[i] < lastParts[i]) return false;
+  }
+
+  return false;
+}
+
+/**
+ * Whether release notes should be offered after a plugin update.
+ * Missing or empty lastSeenVersion is not treated as an update (first run / legacy data).
+ */
+export function shouldOfferReleaseNotes(
+  lastSeenVersion: string | undefined,
+  currentVersion: string
+): boolean {
+  const last = lastSeenVersion?.trim();
+  if (!last) return false;
+  return isNewerVersion(currentVersion, last);
+}


### PR DESCRIPTION
## Summary

Fixes #92

- Adds **Show release notes after plugin update** in plugin settings (default on).
- Shows the changelog modal only when the plugin version actually increased, not on every Obsidian startup.
- On first run (missing `lastSeenVersion`), records the current version silently without opening the modal.
- Migrates `lastSeenVersion` from legacy nested `settings` to the root `PluginData` field when needed.