### PR TITLE
Add vault re-evaluation after rule changes (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.1.0](https://github.com/bueckerlars/obsidian-note-mover-shortcut/compare/1.0.6...1.1.0)
+
+### Features
+
+- **Vault re-evaluation after rule changes** ([#80](https://github.com/bueckerlars/obsidian-note-mover-shortcut/issues/80)): New command **Re-evaluate entire vault with current rules** and a matching button under **Settings → Rules**. Syncs the latest rules, clears the evaluation cache, opens a preview of planned moves, and only moves files when you confirm in the modal.
+
+### Fixes
+
+- **Rule evaluation cache after rule edits**: Saving, deleting, or toggling a rule in settings now calls `updateRuleManager()`, so the in-memory rule engine and evaluation cache stay in sync with your saved rules (previously only clone and reorder did this).
+
 ## [1.0.6](https://github.com/bueckerlars/obsidian-note-mover-shortcut/compare/1.0.5...1.0.6)
 
 ### Fixes

--- a/docs/commands-triggers-internals.md
+++ b/docs/commands-triggers-internals.md
@@ -6,14 +6,15 @@
 
 All commands are available from the **command palette** (Ctrl/Cmd+P). Active-file commands only appear when a Markdown, Canvas, or Base file is open and focused.
 
-| Command                                 | What it does                                                                                                                                               |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Move active note to note folder**     | Evaluates the current note against your rules and moves it if a rule matches. Shows a notification with an Undo link. Also accessible via the ribbon icon. |
-| **Move all files in vault**             | Scans every movable file in the vault and moves each one that matches a rule.                                                                              |
-| **Preview active note movement**        | Shows where the current note _would_ go — without moving anything.                                                                                         |
-| **Preview bulk movement for all files** | Shows a full list of planned moves for every file in the vault — without moving anything.                                                                  |
-| **Show history**                        | Opens the move history modal. View past moves and undo bulk operations.                                                                                    |
-| **Add current file to blacklist**       | Appends `fileName: <current filename>` to your filter list, protecting the open note from future moves.                                                    |
+| Command                                         | What it does                                                                                                                                                                                                                                                                                                                              |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Move active note to note folder**             | Evaluates the current note against your rules and moves it if a rule matches. Shows a notification with an Undo link. Also accessible via the ribbon icon.                                                                                                                                                                                |
+| **Move all files in vault**                     | Scans every movable file in the vault and moves each one that matches a rule.                                                                                                                                                                                                                                                             |
+| **Re-evaluate entire vault with current rules** | Syncs your latest rules, clears the evaluation cache, and opens a **preview** of planned moves for the whole vault. Use this after adding, reordering, or editing rules so already filed notes can move to new destinations. Nothing moves until you confirm in the preview modal. Also available as a button under **Settings → Rules**. |
+| **Preview active note movement**                | Shows where the current note _would_ go — without moving anything.                                                                                                                                                                                                                                                                        |
+| **Preview bulk movement for all files**         | Shows a full list of planned moves for every file in the vault — without moving anything.                                                                                                                                                                                                                                                 |
+| **Show history**                                | Opens the move history modal. View past moves and undo bulk operations.                                                                                                                                                                                                                                                                   |
+| **Add current file to blacklist**               | Appends `fileName: <current filename>` to your filter list, protecting the open note from future moves.                                                                                                                                                                                                                                   |
 
 ### Bulk move: stop mid-run
 
@@ -106,7 +107,7 @@ Configured in **Settings → Performance / debug**.
 
 On by default. Stores the last matched destination per file (keyed by path + modification time + rules/filters hash). When a file hasn't changed and the rules haven't changed, it is skipped during bulk and periodic passes.
 
-The cache is automatically invalidated when you edit a file, rename or delete a file, or change your rules or filters.
+The cache is automatically invalidated when you edit, delete, reorder, or toggle a rule, change filters, rename or delete a file, or edit a file (modify/create). The **Re-evaluate entire vault with current rules** command also clears the cache before generating a preview, so bulk and periodic passes always re-check every file after you intentionally re-scan the vault.
 
 ### Vault index cache
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "nano-staged": {
     "*.{ts,js}": [
-      "eslint --fix --max-warnings 0",
+      "eslint --fix --max-warnings 0 --no-warn-ignored",
       "prettier --write"
     ],
     "*.{json,md}": [

--- a/src/core/AdvancedNoteMover.ts
+++ b/src/core/AdvancedNoteMover.ts
@@ -9,6 +9,7 @@ import AdvancedNoteMoverPlugin from 'main';
 import { type FileMoveResult, type OperationType } from '../types/Common';
 import { showSingleFileMoveNotice } from '../utils/single-file-move-notice';
 import { MovePreview } from '../types/MovePreview';
+import { PreviewModal } from '../modals/PreviewModal';
 import {
   SETTINGS_CONSTANTS,
   NOTIFICATION_CONSTANTS,
@@ -342,6 +343,19 @@ export class AdvancedNoteMover {
     }
     this.lastMoveNoticeAtByFileName.set(file.name, now);
     showSingleFileMoveNotice(file, targetFolder);
+  }
+
+  /**
+   * Re-evaluate the vault with current rules: sync rule manager, invalidate cache,
+   * then open a preview modal before any files are moved.
+   */
+  async openVaultReEvaluationPreview(): Promise<void> {
+    this.updateRuleManager();
+    this.plugin.ruleCache.invalidateAll();
+    const preview = await this.generateVaultMovePreview();
+    new PreviewModal(this.plugin.app, this.plugin, preview, {
+      title: 'Re-evaluate vault',
+    }).open();
   }
 
   /**

--- a/src/core/RuleEvaluationCache.test.ts
+++ b/src/core/RuleEvaluationCache.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { RuleEvaluationCache } from './RuleEvaluationCache';
+import type { RuleV2 } from '../types/RuleV2';
+
+const baseRule: RuleV2 = {
+  name: 'Test rule',
+  destination: 'inbox',
+  aggregation: 'all',
+  triggers: [
+    {
+      criteriaType: 'tag',
+      operator: 'includes item',
+      value: 'test',
+    },
+  ],
+  active: true,
+};
+
+describe('RuleEvaluationCache', () => {
+  it('skips evaluation when cache entry matches path, mtime, and rules hash', () => {
+    const cache = new RuleEvaluationCache();
+    cache.updateRulesHash([baseRule], []);
+
+    cache.store('notes/a.md', 1000, 'inbox');
+    expect(cache.needsEvaluation('notes/a.md', 1000)).toBe(false);
+    expect(cache.getCachedDestination('notes/a.md')).toBe('inbox');
+  });
+
+  it('invalidates all entries when rules hash changes', () => {
+    const cache = new RuleEvaluationCache();
+    cache.updateRulesHash([baseRule], []);
+
+    cache.store('notes/a.md', 1000, 'inbox');
+    expect(cache.needsEvaluation('notes/a.md', 1000)).toBe(false);
+
+    const updatedRule = { ...baseRule, destination: 'archive' };
+    cache.updateRulesHash([updatedRule], []);
+
+    expect(cache.needsEvaluation('notes/a.md', 1000)).toBe(true);
+    expect(cache.getCachedDestination('notes/a.md')).toBeUndefined();
+  });
+
+  it('invalidateAll forces re-evaluation even when rules hash is unchanged', () => {
+    const cache = new RuleEvaluationCache();
+    cache.updateRulesHash([baseRule], []);
+
+    cache.store('notes/a.md', 1000, 'inbox');
+    expect(cache.needsEvaluation('notes/a.md', 1000)).toBe(false);
+
+    cache.invalidateAll();
+
+    expect(cache.needsEvaluation('notes/a.md', 1000)).toBe(true);
+    expect(cache.getCachedDestination('notes/a.md')).toBeUndefined();
+  });
+
+  it('marks dirty files for re-evaluation without clearing other entries', () => {
+    const cache = new RuleEvaluationCache();
+    cache.updateRulesHash([baseRule], []);
+
+    cache.store('notes/a.md', 1000, 'inbox');
+    cache.store('notes/b.md', 2000, 'tasks');
+
+    cache.markDirty('notes/a.md');
+
+    expect(cache.needsEvaluation('notes/a.md', 1000)).toBe(true);
+    expect(cache.needsEvaluation('notes/b.md', 2000)).toBe(false);
+  });
+});

--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -67,6 +67,22 @@ export class CommandHandler {
       },
     });
 
+    // Re-evaluate entire vault after rule changes (preview first)
+    this.plugin.addCommand({
+      id: 're-evaluate-vault-with-rules',
+      name: 'Re-evaluate entire vault with current rules',
+      callback: async () => {
+        try {
+          await this.plugin.advancedNoteMover.openVaultReEvaluationPreview();
+        } catch (error) {
+          handleError(error, 'Error generating preview', false);
+          NoticeManager.error(
+            `Error generating preview: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      },
+    });
+
     // Preview single note movement command
     this.plugin.addCommand({
       id: 'preview-note-movement',

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -151,6 +151,7 @@ export class AdvancedNoteMoverSettingsTab extends PluginSettingTab {
 
     this.rulesSettings.addRulesSetting();
     this.rulesSettings.addRulesArray();
+    this.rulesSettings.addVaultReEvaluationSetting();
     this.rulesSettings.addAddRuleButtonSetting();
 
     this.attachmentsSettings.addAttachmentSettings();

--- a/src/settings/sections/RulesSettingsSection.ts
+++ b/src/settings/sections/RulesSettingsSection.ts
@@ -1,5 +1,5 @@
 import AdvancedNoteMoverPlugin from 'main';
-import { App, Setting } from 'obsidian';
+import { App, ButtonComponent, Setting } from 'obsidian';
 import { SETTINGS_CONSTANTS } from '../../config/constants';
 import { DragDropManager } from '../../utils/DragDropManager';
 import { RuleEditorModal } from '../../modals/RuleEditorModal';
@@ -7,6 +7,8 @@ import { RuleV2 } from '../../types/RuleV2';
 import { MobileUtils } from '../../utils/MobileUtils';
 import { ConfirmModal } from '../../modals/ConfirmModal';
 import { toMarkdownInlineCode } from '../../utils/markdown-confirm';
+import { handleError } from '../../utils/Error';
+import { NoticeManager } from '../../utils/NoticeManager';
 
 export class RulesSettingsSection {
   private dragDropManager: DragDropManager | null = null;
@@ -30,6 +32,43 @@ export class RulesSettingsSection {
     new Setting(this.containerEl).setDesc(descUseRules);
   }
 
+  addVaultReEvaluationSetting(): void {
+    let reEvaluateButton: ButtonComponent | undefined;
+
+    new Setting(this.containerEl)
+      .setName('Re-evaluate vault')
+      .setDesc(
+        'After changing rules, preview which files would move to their new destinations before applying any moves.'
+      )
+      .addButton(btn => {
+        reEvaluateButton = btn
+          .setButtonText('Re-evaluate vault with current rules')
+          .onClick(() => {
+            if (reEvaluateButton) {
+              reEvaluateButton.setDisabled(true);
+              reEvaluateButton.setButtonText('Generating preview…');
+            }
+            void (async () => {
+              try {
+                await this.plugin.advancedNoteMover.openVaultReEvaluationPreview();
+              } catch (error) {
+                handleError(error, 'Error generating vault preview', false);
+                NoticeManager.error(
+                  `Error generating preview: ${error instanceof Error ? error.message : String(error)}`
+                );
+              } finally {
+                if (reEvaluateButton) {
+                  reEvaluateButton.setDisabled(false);
+                  reEvaluateButton.setButtonText(
+                    'Re-evaluate vault with current rules'
+                  );
+                }
+              }
+            })();
+          });
+      });
+  }
+
   addAddRuleButtonSetting(): void {
     new Setting(this.containerEl).addButton(btn =>
       btn
@@ -47,6 +86,12 @@ export class RulesSettingsSection {
 
   private get app(): App {
     return this.plugin.app;
+  }
+
+  private async persistRulesAndSyncManager(): Promise<void> {
+    await this.plugin.save_settings();
+    this.plugin.advancedNoteMover.updateRuleManager();
+    this.refreshDisplay();
   }
 
   /**
@@ -136,8 +181,7 @@ export class RulesSettingsSection {
             });
             if (confirmed) {
               this.plugin.settings.settings.rulesV2!.splice(index, 1);
-              await this.plugin.save_settings();
-              this.refreshDisplay();
+              await this.persistRulesAndSyncManager();
             }
           })
       );
@@ -159,9 +203,7 @@ export class RulesSettingsSection {
               0,
               clonedRule
             );
-            await this.plugin.save_settings();
-            this.plugin.advancedNoteMover.updateRuleManager();
-            this.refreshDisplay();
+            await this.persistRulesAndSyncManager();
           })
       );
 
@@ -182,7 +224,7 @@ export class RulesSettingsSection {
           .setTooltip(rule.active ? 'Rule is active' : 'Rule is inactive')
           .onChange(async value => {
             this.plugin.settings.settings.rulesV2![index].active = value;
-            await this.plugin.save_settings();
+            await this.persistRulesAndSyncManager();
           })
       );
 
@@ -215,9 +257,7 @@ export class RulesSettingsSection {
         this.reorderRulesV2(fromIndex, toIndex);
       },
       onSave: async () => {
-        await this.plugin.save_settings();
-        this.plugin.advancedNoteMover.updateRuleManager();
-        this.refreshDisplay();
+        await this.persistRulesAndSyncManager();
       },
       itemSelector: '.setting-item',
       handleSelector: '.advancedNoteMover-drag-handle',
@@ -279,14 +319,12 @@ export class RulesSettingsSection {
           this.plugin.settings.settings.rulesV2.push(updatedRule);
         }
 
-        await this.plugin.save_settings();
-        this.refreshDisplay();
+        await this.persistRulesAndSyncManager();
       },
       onDelete: isEditMode
         ? async () => {
             this.plugin.settings.settings.rulesV2!.splice(ruleIndex, 1);
-            await this.plugin.save_settings();
-            this.refreshDisplay();
+            await this.persistRulesAndSyncManager();
           }
         : undefined,
       vaultIndexCache: this.plugin.vaultIndexCache,


### PR DESCRIPTION
Introduce a preview-first command and settings button to re-sort notes when
rules change, and sync the rule evaluation cache whenever rules are edited,
deleted, or toggled in settings.