### PR TITLE
fix: restore rule editor Save/Cancel/Remove actions and unsaved-changes guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.1.0](https://github.com/bueckerlars/obsidian-note-mover-shortcut/compare/1.0.6...1.1.0)
+
+### Fixes
+
+- **Rule editor footer**: Save, Cancel, and Remove rule buttons were rendered but often invisible or not clickable on desktop because the footer used Obsidian `Setting` wrappers without a label, leaving an empty `.setting-item-info` that broke the layout. The footer now uses `BaseModal` button helpers (same pattern as the preview modal), so all actions are visible and clickable again.
+- **Remove rule in editor**: Deleting a rule from the editor footer works again — confirm dialog, removal, and list refresh.
+
+### Improvements
+
+- **Unsaved changes guard**: Closing the rule editor with unsaved edits (Cancel, X, or Esc) shows a confirmation dialog before discarding changes.
+- **Sticky rule editor footer**: Action buttons stay reachable when editing rules with many conditions.
+
 ## [1.0.6](https://github.com/bueckerlars/obsidian-note-mover-shortcut/compare/1.0.5...1.0.6)
 
 ### Fixes

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -98,6 +98,9 @@ export const SETTINGS_CONSTANTS = {
     // Rule / confirm copy
     DELETE_RULE_TITLE: 'Delete rule',
     DELETE_RULE_CONFIRM: 'Delete',
+    DISCARD_CHANGES_TITLE: 'Unsaved changes',
+    DISCARD_CHANGES_MESSAGE: 'You have unsaved changes. Discard them?',
+    DISCARD_CHANGES_CONFIRM: 'Discard',
     // Retention policy texts
     RETENTION_POLICY_TITLE: 'Retention Policy',
     RETENTION_POLICY_DESC: 'Configure how long history entries should be kept',

--- a/src/modals/RuleEditorModal.ts
+++ b/src/modals/RuleEditorModal.ts
@@ -37,6 +37,8 @@ interface RuleEditorModalOptions {
 export class RuleEditorModal extends BaseModal {
   private ruleOptions: RuleEditorModalOptions;
   private workingRule: RuleV2;
+  private originalRule: RuleV2;
+  private isForceClosing = false;
   private dragDropManager: DragDropManager | null = null;
   private triggersContainer: HTMLElement | null = null;
 
@@ -48,8 +50,8 @@ export class RuleEditorModal extends BaseModal {
       autoFocus: false, // Disable auto focus to prevent scroll issues on mobile
     });
     this.ruleOptions = options;
-    // Create a working copy of the rule
     this.workingRule = structuredClone(options.rule);
+    this.originalRule = structuredClone(options.rule);
   }
 
   protected createContent(): void {
@@ -456,59 +458,98 @@ export class RuleEditorModal extends BaseModal {
 
   private createFooterActions(container: HTMLElement): void {
     const footer = container.createDiv({
-      cls: 'advancedNoteMover-rule-editor-footer',
+      cls: 'advancedNoteMover-rule-editor-footer advancedNoteMover-modal-footer',
     });
 
-    // Remove Rule button (only in edit mode)
     if (this.ruleOptions.isEditMode && this.ruleOptions.onDelete) {
       const leftSide = footer.createDiv({
         cls: 'advancedNoteMover-rule-editor-footer-left',
       });
-      new Setting(leftSide).addButton(btn =>
-        btn
-          .setButtonText('Remove rule')
-          .setDestructive()
-          .onClick(() => {
-            void (async () => {
-              const ruleLabel = toMarkdownInlineCode(this.workingRule.name);
-              const confirmed = await ConfirmModal.show(this.app, {
-                title: SETTINGS_CONSTANTS.UI_TEXTS.DELETE_RULE_TITLE,
-                message: `Are you sure you want to delete the rule ${ruleLabel}?\n\nThis action cannot be undone.`,
-                confirmText: SETTINGS_CONSTANTS.UI_TEXTS.DELETE_RULE_CONFIRM,
-                cancelText: 'Cancel',
-                danger: true,
-              });
-              if (confirmed && this.ruleOptions.onDelete) {
-                await this.ruleOptions.onDelete();
-                this.close();
-              }
-            })();
-          })
+      const leftButtons = this.createButtonContainer(leftSide);
+      this.createButton(
+        leftButtons,
+        'Remove rule',
+        () => {
+          void this.handleRemoveRule();
+        },
+        { isWarning: true }
       );
     }
 
-    // Right side: Cancel and Save
     const rightSide = footer.createDiv({
       cls: 'advancedNoteMover-rule-editor-footer-right',
     });
+    const rightButtons = this.createButtonContainer(rightSide);
 
-    new Setting(rightSide)
-      .addButton(btn =>
-        btn.setButtonText('Cancel').onClick(() => {
-          this.close();
-        })
-      )
-      .addButton(btn =>
-        btn
-          .setButtonText('Save')
-          .setCta()
-          .onClick(async () => {
-            if (this.validateRule()) {
-              await this.ruleOptions.onSave(this.workingRule);
-              this.close();
-            }
-          })
-      );
+    this.createButton(rightButtons, 'Cancel', () => {
+      void this.requestClose();
+    });
+
+    this.createButton(
+      rightButtons,
+      'Save',
+      () => {
+        void this.handleSave();
+      },
+      { isPrimary: true }
+    );
+  }
+
+  private async handleSave(): Promise<void> {
+    if (!this.validateRule()) {
+      return;
+    }
+    await this.ruleOptions.onSave(this.workingRule);
+    this.isForceClosing = true;
+    super.close();
+  }
+
+  private async handleRemoveRule(): Promise<void> {
+    const ruleLabel = toMarkdownInlineCode(this.workingRule.name);
+    const confirmed = await ConfirmModal.show(this.app, {
+      title: SETTINGS_CONSTANTS.UI_TEXTS.DELETE_RULE_TITLE,
+      message: `Are you sure you want to delete the rule ${ruleLabel}?\n\nThis action cannot be undone.`,
+      confirmText: SETTINGS_CONSTANTS.UI_TEXTS.DELETE_RULE_CONFIRM,
+      cancelText: 'Cancel',
+      danger: true,
+    });
+    if (confirmed && this.ruleOptions.onDelete) {
+      await this.ruleOptions.onDelete();
+      this.isForceClosing = true;
+      super.close();
+    }
+  }
+
+  private hasUnsavedChanges(): boolean {
+    return (
+      JSON.stringify(this.workingRule) !== JSON.stringify(this.originalRule)
+    );
+  }
+
+  private async requestClose(): Promise<void> {
+    this.close();
+  }
+
+  private async confirmDiscardAndClose(): Promise<void> {
+    const confirmed = await ConfirmModal.show(this.app, {
+      title: SETTINGS_CONSTANTS.UI_TEXTS.DISCARD_CHANGES_TITLE,
+      message: SETTINGS_CONSTANTS.UI_TEXTS.DISCARD_CHANGES_MESSAGE,
+      confirmText: SETTINGS_CONSTANTS.UI_TEXTS.DISCARD_CHANGES_CONFIRM,
+      cancelText: 'Cancel',
+      danger: true,
+    });
+    if (confirmed) {
+      this.isForceClosing = true;
+      super.close();
+    }
+  }
+
+  close(): void {
+    if (this.isForceClosing || !this.hasUnsavedChanges()) {
+      super.close();
+      return;
+    }
+    void this.confirmDiscardAndClose();
   }
 
   private validateRule(): boolean {

--- a/styles.css
+++ b/styles.css
@@ -924,26 +924,30 @@
   align-items: center;
   margin-top: 20px;
   padding-top: 16px;
+  padding-bottom: 4px;
   border-top: 1px solid var(--background-modifier-border);
   flex-shrink: 0;
-}
-
-.advancedNoteMover-rule-editor-footer .setting-item {
-  border: none;
-  padding: 0;
-  margin: 0;
+  position: sticky;
+  bottom: 0;
+  background: var(--background-primary);
+  z-index: 2;
 }
 
 .advancedNoteMover-rule-editor-footer-left,
 .advancedNoteMover-rule-editor-footer-right {
   display: flex;
   gap: 8px;
+  align-items: center;
 }
 
-.advancedNoteMover-rule-editor-footer-left .setting-item-control,
-.advancedNoteMover-rule-editor-footer-right .setting-item-control {
-  flex: 0 0 auto;
-  width: auto;
+.advancedNoteMover-rule-editor-footer-left
+  .advancedNoteMover-modal-button-container {
+  justify-content: flex-start;
+}
+
+.advancedNoteMover-rule-editor-footer-right
+  .advancedNoteMover-modal-button-container {
+  justify-content: flex-end;
 }
 
 /* Property Suggestions */


### PR DESCRIPTION
## Summary

- Fix rule editor footer actions (Save, Cancel, Remove rule) that were rendered but often invisible or not clickable due to `Setting` wrapper layout issues
- Refactor footer to use `createButtonContainer()` / `createButton()` from `BaseModal`, matching the pattern already used in `PreviewModal`
- Add unsaved-changes protection: closing via Cancel, X, or Esc prompts before discarding edits
- Update footer CSS with sticky positioning so action buttons stay reachable when editing rules with many conditions

## Changes

- `src/modals/RuleEditorModal.ts` — footer refactor, dirty-state tracking, `close()` override, dedicated save/remove handlers
- `src/config/constants.ts` — discard-changes dialog copy
- `styles.css` — sticky footer layout and button-container alignment

## Test plan

- [x] Create a new rule: Save and Cancel are visible; Save persists the rule
- [x] Edit an existing rule: change a field, click Save — changes are saved
- [x] Edit a rule, make changes, click Cancel — unsaved-changes dialog appears; Discard closes without saving; Cancel keeps editor open
- [x] Edit a rule, make changes, close via X or Esc — same unsaved-changes dialog behavior
- [x] Edit a rule, click Remove rule — confirm dialog appears; rule is deleted from the list
- [x] Narrow desktop window (~700px): footer buttons remain visible and clickable